### PR TITLE
change Rentalrepository.getRentalFiltered signature to be more durable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Évaluation Technique
-
+Modification 2/21/2021 :
+Je me suis rendu compte que d'avoir un prédicat dans la méthode getRentalsFiltered dans RentalRepository causerait des
+problèmes à long terme. Si on décide d'implémenter une base de données avec un Orm qui filtre les données lui-même, le
+prédicat ne sert plus et on aurait besoin des valeurs directement. Donc, mon changement vient contrer ce problème en
+passant un dto qui donne les données nécessaires.
 ## Énoncé
 
 L'objectif de ce test est d'évaluer vos aptitudes techniques dans leur ensemble en vous demandant de produire une API HTTP REST.

--- a/src/api/context/RentalContext.ts
+++ b/src/api/context/RentalContext.ts
@@ -1,10 +1,11 @@
 import { RentalController } from "../controllers/RentalController";
 import { CSVRentalRepository } from "../../infrastructure/CSVRentalRepository";
 import RentalService from "../../domain/rental/RentalService";
+import RentalFilterPredicateFactory from "../../domain/rental/filter/RentalFilterPredicateFactory";
 
 export class RentalContext {
     async getRentalController(): Promise<RentalController> {
-        const rentalRepository = new CSVRentalRepository("./db/rentals.csv");
+        const rentalRepository = new CSVRentalRepository("./db/rentals.csv", new RentalFilterPredicateFactory());
         await rentalRepository.initDatabase();
         const rentalService = new RentalService(rentalRepository);
         return new RentalController(rentalService);

--- a/src/api/controllers/RentalController.ts
+++ b/src/api/controllers/RentalController.ts
@@ -1,9 +1,7 @@
 import {Request, Response} from "express";
 import Rental from "../../domain/rental/Rentals";
 import RentalService from "../../domain/rental/RentalService";
-import RentalFilterPredicateFactory from "../../domain/rental/filter/RentalFilterPredicateFactory";
 import RentalFilterDto from "../../domain/rental/RentalFilterDto";
-
 
 export class RentalController {
     private readonly rentalService: RentalService;
@@ -13,7 +11,6 @@ export class RentalController {
     }
 
     getRentals = (req: Request, res: Response): void => {
-        const rentalFilterBuilder = new RentalFilterPredicateFactory();
         const query = req.query;
 
         const rentalFilterDto: RentalFilterDto = {

--- a/src/api/controllers/RentalController.ts
+++ b/src/api/controllers/RentalController.ts
@@ -1,7 +1,8 @@
-import { Request, Response } from "express";
+import {Request, Response} from "express";
 import Rental from "../../domain/rental/Rentals";
 import RentalService from "../../domain/rental/RentalService";
-import RentalFilterBuilder from "../../domain/rental/filter/RentalFilterBuilder";
+import RentalFilterPredicateFactory from "../../domain/rental/filter/RentalFilterPredicateFactory";
+import RentalFilterDto from "../../domain/rental/RentalFilterDto";
 
 
 export class RentalController {
@@ -12,24 +13,25 @@ export class RentalController {
     }
 
     getRentals = (req: Request, res: Response): void => {
-        const rentalFilterBuilder = new RentalFilterBuilder();
+        const rentalFilterBuilder = new RentalFilterPredicateFactory();
         const query = req.query;
 
-        rentalFilterBuilder
-            .withPostalCode(query.postalcode && query.postalcode.toString())
-            .withMinBed(query.min_nb_beds && Number(query.min_nb_beds))
-            .withMinPrice(query.min_price && Number(query.min_price))
-            .withMaxPrice(query.min_price && Number(query.max_price));
+        const rentalFilterDto: RentalFilterDto = {
+            postalCode: query.postalcode && query.postalcode.toString(),
+            nbBed: query.min_nb_beds && Number(query.min_nb_beds),
+            minPrice: query.min_price && Number(query.min_price),
+            maxPrice: query.min_price && Number(query.max_price)
+        };
 
-        const rentals: Rental[] = this.rentalService.getRentalsFiltered(rentalFilterBuilder);
+        const rentals: Rental[] = this.rentalService.getRentalsFiltered(rentalFilterDto);
         res.send(rentals);
-    }
+    };
 
     getRentalById = (req: Request, res: Response): void => {
         const id: string = req.params.id;
         const rental: Rental = this.rentalService.getRental(id);
 
-        if(rental) {
+        if (rental) {
             res.send(rental);
         } else {
             res.status(404).send("Rental not found");

--- a/src/domain/rental/RentalFilterDto.ts
+++ b/src/domain/rental/RentalFilterDto.ts
@@ -1,0 +1,8 @@
+interface RentalFilterDto {
+    postalCode: string;
+    nbBed: number;
+    minPrice: number;
+    maxPrice: number;
+}
+
+export default RentalFilterDto;

--- a/src/domain/rental/RentalRepository.ts
+++ b/src/domain/rental/RentalRepository.ts
@@ -1,9 +1,10 @@
 import Rental from "./Rentals";
+import RentalFilterDto from "./RentalFilterDto";
 
 interface RentalRepository  {
     getRentals(): Rental[];
 
-    getRentalsFiltered(predicate: (rental: Rental) => boolean): Rental[];
+    getRentalsFiltered(rentalFilterDto: RentalFilterDto): Rental[];
 
     getRental(id: string): Rental;
 }

--- a/src/domain/rental/RentalService.ts
+++ b/src/domain/rental/RentalService.ts
@@ -1,6 +1,7 @@
 import RentalRepository from "./RentalRepository";
 import Rental from "./Rentals";
-import RentalFilterBuilder from "./filter/RentalFilterBuilder";
+import RentalFilterPredicateFactory from "./filter/RentalFilterPredicateFactory";
+import RentalFilterDto from "./RentalFilterDto";
 
 
 export default class RentalService {
@@ -10,9 +11,9 @@ export default class RentalService {
         this.rentalRepository = rentalRepository;
     }
 
-    getRentalsFiltered(rentalFilterBuilder: RentalFilterBuilder): Rental[] {
-        const predicate = rentalFilterBuilder.build();
-        return this.rentalRepository.getRentalsFiltered(predicate);
+    getRentalsFiltered(rentalFilterDTO: RentalFilterDto): Rental[] {
+
+        return this.rentalRepository.getRentalsFiltered(rentalFilterDTO);
     }
 
     getRental(id:string):Rental {

--- a/src/domain/rental/filter/RentalFilterPredicateFactory.ts
+++ b/src/domain/rental/filter/RentalFilterPredicateFactory.ts
@@ -1,12 +1,21 @@
 import Rental from "../Rentals";
 
-export default class RentalFilterBuilder {
+export default class RentalFilterPredicateFactory {
     private minBed : number
-    private postalCodeFilter: string
+    private postalCode: string
     private minPrice: number
     private maxPrice: number
 
-    build() :(rental: Rental) => boolean {
+    create(minBed: number, postalCode: string, minPrice: number, maxPrice: number): (rental: Rental) => boolean {
+        this.minBed = minBed;
+        this.postalCode = postalCode;
+        this.minPrice = minPrice;
+        this.maxPrice = maxPrice;
+
+        return this.buildPredicate();
+    }
+
+    private buildPredicate() :(rental: Rental) => boolean {
         return  (rental: Rental): boolean => {
             const conditions = [this.isMinBedRentalInvalid,
             this.isMinPriceRentalInvalid,
@@ -31,34 +40,14 @@ export default class RentalFilterBuilder {
 
     private isPostalCodeRentalInvalid = (rental:Rental): boolean => {
         const postalCode = rental.postalCode;
-        if(this.postalCodeFilter && this.postalCodeFilter.length == 6) {
+        if(this.postalCode && this.postalCode.length == 6) {
             for (let i = 0; i < 6; i++ ) {
-                const character = this.postalCodeFilter[i];
+                const character = this.postalCode[i];
                 if (character != "_" && character != postalCode[i]) {
                     return true;
                 }
             }
         }
         return false;
-    }
-
-    withMinBed(nb: number): RentalFilterBuilder {
-        this.minBed = nb;
-        return this;
-    }
-
-    withPostalCode(postalCode: string): RentalFilterBuilder {
-        this.postalCodeFilter = postalCode;
-        return this;
-    }
-
-    withMinPrice(minPrice: number): RentalFilterBuilder {
-        this.minPrice = minPrice;
-        return this;
-    }
-
-    withMaxPrice(maxPrice: number): RentalFilterBuilder {
-        this.maxPrice = maxPrice;
-        return this;
     }
 }

--- a/src/infrastructure/CSVRentalRepository.ts
+++ b/src/infrastructure/CSVRentalRepository.ts
@@ -2,14 +2,18 @@ import RentalRepository from "../domain/rental/RentalRepository";
 import fs from "fs";
 import csv from "csv-parser";
 import Rental from "../domain/rental/Rentals";
+import RentalFilterDto from "../domain/rental/RentalFilterDto";
+import RentalFilterPredicateFactory from "../domain/rental/filter/RentalFilterPredicateFactory";
 
 export class CSVRentalRepository implements RentalRepository {
 
     private rentals: Map<string, Rental> = new Map();
     private path: string;
+    private rentalFilterBuilder: RentalFilterPredicateFactory;
 
-    constructor(path : string) {
+    constructor(path: string,rentalFilterBuilder :RentalFilterPredicateFactory) {
         this.path = path;
+        this.rentalFilterBuilder = rentalFilterBuilder;
     }
 
     async initDatabase(): Promise<void> {
@@ -20,7 +24,17 @@ export class CSVRentalRepository implements RentalRepository {
                 })
                 .pipe(csv())
                 .on("data", (row) => {
-                    const rental: Rental = { id: row.id, city: row.city, postalCode: row.postalcode, price: row.price, nbBed: row.nb_beds, nbBath: row.nb_baths, owner: row.owner, rating: row.rating, description: row.description }
+                    const rental: Rental = {
+                        id: row.id,
+                        city: row.city,
+                        postalCode: row.postalcode,
+                        price: row.price,
+                        nbBed: row.nb_beds,
+                        nbBath: row.nb_baths,
+                        owner: row.owner,
+                        rating: row.rating,
+                        description: row.description
+                    };
                     this.rentals.set(rental.id, rental);
                 })
                 .on("end", () => {
@@ -33,7 +47,12 @@ export class CSVRentalRepository implements RentalRepository {
         return [...this.rentals.values()];
     }
 
-    getRentalsFiltered(predicate: (rental: Rental) => boolean): Rental[] {
+    getRentalsFiltered(rentalFilterDto: RentalFilterDto): Rental[] {
+        const predicate = this.rentalFilterBuilder.create(rentalFilterDto.nbBed,
+            rentalFilterDto.postalCode,
+            rentalFilterDto.minPrice,
+            rentalFilterDto.maxPrice);
+
         return this.getRentals().filter(predicate);
     }
 

--- a/test/unit/domain/rental/RentalService.test.ts
+++ b/test/unit/domain/rental/RentalService.test.ts
@@ -1,50 +1,35 @@
 import RentalService from "../../../../src/domain/rental/RentalService";
 import {instance, mock, verify, when} from "ts-mockito";
-import RentalFilterBuilder from "../../../../src/domain/rental/filter/RentalFilterBuilder";
 import RentalRepository from "../../../../src/domain/rental/RentalRepository";
 import Rental from "../../../../src/domain/rental/Rentals";
+import RentalFilterDto from "../../../../src/domain/rental/RentalFilterDto";
 
 describe("RentalService tests", () => {
+    const rentalFilterDto: RentalFilterDto = {postalCode: undefined, maxPrice: undefined, minPrice:undefined, nbBed:undefined}
     let rentalService: RentalService;
-    let rentalFilterBuilder : RentalFilterBuilder;
     let rentalRepository: RentalRepository;
 
     beforeEach(() => {
         rentalRepository= mock<RentalRepository>();
-        rentalFilterBuilder= mock(RentalFilterBuilder);
         rentalService =new RentalService(instance(rentalRepository));
     });
 
     describe("getRentalsFiltered", () => {
-        it("call rentalFilterBuilder.build()", ()=> {
-            rentalService.getRentalsFiltered(instance(rentalFilterBuilder));
-
-            verify(rentalFilterBuilder.build()).once();
-        });
-
         it("call rentalRepository.getRentalsFiltered", ()=> {
-            const predicate = mock(() => false);
-            when(rentalFilterBuilder.build()).thenReturn(predicate);
+            rentalService.getRentalsFiltered(rentalFilterDto);
 
-            rentalService.getRentalsFiltered(instance(rentalFilterBuilder));
-
-            verify(rentalRepository.getRentalsFiltered(predicate)).once();
+            verify(rentalRepository.getRentalsFiltered(rentalFilterDto)).once();
         });
 
         it("return rentals", ()=> {
-            const predicate = mock(() => false);
-            when(rentalFilterBuilder.build()).thenReturn(predicate);
-            const rentals: Rental[] = [];
-            when(rentalRepository.getRentalsFiltered(predicate)).thenReturn(rentals);
+            const rentalsFiltered = rentalService.getRentalsFiltered(rentalFilterDto);
 
-            const rentalsFiltered = rentalService.getRentalsFiltered(instance(rentalFilterBuilder));
-
-            expect(rentalsFiltered).toBe(rentals);
+            expect(rentalsFiltered).toBeDefined();
         });
     });
 
     describe("getById", () => {
-        it("call rentalFilterBuilder.build()", ()=> {
+        it("call getRental", ()=> {
             const id = "1234";
 
             rentalService.getRental(id);

--- a/test/unit/domain/rental/filter/RentalFilterBuilder.test.ts
+++ b/test/unit/domain/rental/filter/RentalFilterBuilder.test.ts
@@ -1,5 +1,6 @@
-import RentalFilterBuilder from "../../../../../src/domain/rental/filter/RentalFilterBuilder";
+import RentalFilterPredicateFactory from "../../../../../src/domain/rental/filter/RentalFilterPredicateFactory";
 import Rental from "../../../../../src/domain/rental/Rentals";
+import RentalFilterDto from "../../../../../src/domain/rental/RentalFilterDto";
 
 describe("RentalFilterBuilder tests", () => {
     const nbBed = 2;
@@ -13,62 +14,56 @@ describe("RentalFilterBuilder tests", () => {
         nbBed, rating: 4,
         nbBath, id: "1234"
     };
-    let rentalFilterBuilder: RentalFilterBuilder;
+    let rentalFilterPredicateFactory: RentalFilterPredicateFactory;
 
     beforeEach(() => {
-        rentalFilterBuilder = new RentalFilterBuilder();
+        rentalFilterPredicateFactory = new RentalFilterPredicateFactory();
     });
 
     describe("with min bed", () => {
         it("when valid should BeTruthy ", function () {
-            rentalFilterBuilder.withMinBed(nbBed);
+            const predicate = rentalFilterPredicateFactory.create(nbBed, undefined, undefined, undefined);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeTruthy();
         });
 
         it("when invalide should BeFalsy", function () {
-            rentalFilterBuilder.withMinBed(nbBed + 1);
+            const predicate = rentalFilterPredicateFactory.create(nbBed + 1, undefined, undefined, undefined);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeFalsy();
         });
     });
 
     describe("with min price", () => {
         it("when valid should BeTruthy ", function () {
-            rentalFilterBuilder.withMinPrice(price);
+            const predicate = rentalFilterPredicateFactory.create(undefined, undefined, price, undefined);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeTruthy();
         });
 
         it("when invalide should BeFalsy", function () {
-            rentalFilterBuilder.withMinPrice(price + 1);
+            const predicate = rentalFilterPredicateFactory.create(undefined, undefined, price + 1, undefined);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeFalsy();
         });
     });
 
     describe("with max price", () => {
         it("when valid should BeTruthy ", function () {
-            rentalFilterBuilder.withMaxPrice(price);
+            const predicate = rentalFilterPredicateFactory.create(undefined, undefined, undefined, price);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeTruthy();
         });
 
         it("when invalide should BeFalsy", function () {
-            rentalFilterBuilder.withMaxPrice(price - 1);
+            const predicate = rentalFilterPredicateFactory.create(undefined, undefined, undefined, price - 1);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeFalsy();
         });
     });
@@ -76,19 +71,17 @@ describe("RentalFilterBuilder tests", () => {
     describe("with postal code", () => {
         it("when valid should BeTruthy ", function () {
             const postalCodeValidFilter = "G3__G4";
-            rentalFilterBuilder.withPostalCode(postalCodeValidFilter);
+            const predicate = rentalFilterPredicateFactory.create(undefined, postalCodeValidFilter, undefined, undefined);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeTruthy();
         });
 
         it("when invalide should BeFalsy", function () {
             const postalCodeInvalidFilter = "G4__G4";
-            rentalFilterBuilder.withPostalCode(postalCodeInvalidFilter);
+            const predicate = rentalFilterPredicateFactory.create(undefined, postalCodeInvalidFilter, undefined, undefined);
 
-            const isValid = rentalFilterBuilder.build()(rental);
-
+            const isValid = predicate(rental);
             expect(isValid).toBeFalsy();
         });
     });

--- a/test/unit/infrastructure/CSVRentalRepository.test.ts
+++ b/test/unit/infrastructure/CSVRentalRepository.test.ts
@@ -1,18 +1,48 @@
 import {CSVRentalRepository} from "../../../src/infrastructure/CSVRentalRepository";
 import Rental from "../../../src/domain/rental/Rentals";
+import {instance, mock, verify, when} from "ts-mockito";
+import RentalFilterPredicateFactory from "../../../src/domain/rental/filter/RentalFilterPredicateFactory";
+import RentalFilterDto from "../../../src/domain/rental/RentalFilterDto";
 
 
 describe("CSVRentalRepository tests", () => {
-    let csvRentalRepository:CSVRentalRepository;
+    let csvRentalRepository: CSVRentalRepository;
+    let rentalFilterPredicateFactory: RentalFilterPredicateFactory;
     beforeEach(async () => {
         const validPath = "./db/rentalsTest.csv";
-        csvRentalRepository= new CSVRentalRepository(validPath);
+        rentalFilterPredicateFactory = mock(RentalFilterPredicateFactory);
+        csvRentalRepository = new CSVRentalRepository(validPath, instance(rentalFilterPredicateFactory));
         await csvRentalRepository.initDatabase();
     });
-    
+
+    describe("getRentalsFiltered", () => {
+        const rentalFilterDto: RentalFilterDto = {
+            nbBed: undefined,
+            minPrice: undefined,
+            maxPrice: undefined,
+            postalCode: undefined
+        };
+
+        it("should return rentals", function () {
+            when(rentalFilterPredicateFactory.create(rentalFilterDto.nbBed, rentalFilterDto.postalCode, rentalFilterDto.minPrice, rentalFilterDto.maxPrice))
+                .thenReturn(() => true);
+
+            const rentals: Rental[] = csvRentalRepository.getRentalsFiltered(rentalFilterDto);
+
+            expect(rentals.length).toBeGreaterThan(0);
+        });
+
+        it("should call rentalFilterPredicateFactory.create", function () {
+            csvRentalRepository.getRentals();
+
+            verify(rentalFilterPredicateFactory.create(rentalFilterDto.nbBed, rentalFilterDto.postalCode, rentalFilterDto.minPrice, rentalFilterDto.maxPrice));
+        });
+    });
+
     describe("getRentals", () => {
         it("should return rentals", function () {
             const rentals: Rental[] = csvRentalRepository.getRentals();
+
             expect(rentals.length).toBeGreaterThan(0);
         });
     });
@@ -20,11 +50,13 @@ describe("CSVRentalRepository tests", () => {
     describe("getRental", () => {
         it("with valid id should return rental", function () {
             const rental: Rental = csvRentalRepository.getRental("49eaf6af-b8f7-4cb2-ba9e-bdf49e1c27b4");
+
             expect(rental).toBeDefined();
         });
 
         it("invalid id should return undefined", function () {
             const rental: Rental = csvRentalRepository.getRental("1234");
+
             expect(rental).toBeUndefined();
         });
     });


### PR DESCRIPTION
Je me suis rendu compte que d'avoir un prédicat dans la méthode getRentalsFiltered dans RentalRepository causerait des
problèmes à long terme. Si on décide d'implémenter une base de données avec un Orm qui filtre les données lui-même, le
prédicat ne sert plus et on aurait besoin des valeurs directement. Donc, mon changement vient contrer ce problème en
passant un dto qui donne les données nécessaires.